### PR TITLE
Remove VPC subnet CIDRs as input variable

### DIFF
--- a/modules/devbox/main.tf
+++ b/modules/devbox/main.tf
@@ -53,12 +53,12 @@ resource "aws_launch_template" "base" {
 
   # seems to duplicate the drive here
   #block_device_mappings {
-    #device_name = "/dev/xvda"
-    #ebs {
-      #volume_size           = 45
-      #volume_type           = "gp3"
-      #delete_on_termination = false
-    #}
+  #device_name = "/dev/xvda"
+  #ebs {
+  #volume_size           = 45
+  #volume_type           = "gp3"
+  #delete_on_termination = false
+  #}
   #}
 
   tags = {

--- a/modules/snapshot-lambda/main.tf
+++ b/modules/snapshot-lambda/main.tf
@@ -70,7 +70,7 @@ EOT
 data "aws_ecr_image" "latest" {
   repository_name = aws_ecr_repository.snapshot_lambda.name
   image_tag       = "latest"
-  depends_on = [null_resource.build_and_push]
+  depends_on      = [null_resource.build_and_push]
 }
 
 

--- a/modules/vpc/outputs.tf
+++ b/modules/vpc/outputs.tf
@@ -4,8 +4,11 @@ output "vpc_id" {
 }
 
 output "subnet_ids" {
-  description = "The IDs of the created Subnets"
-  value       = aws_subnet.this[*].id
+  description = "The IDs of the created Subnets, in AZ order"
+  value = [
+    for az in data.aws_availability_zones.available.names :
+    aws_subnet.this[az].id
+  ]
 }
 
 output "ssh_sg_id" {

--- a/modules/vpc/variables.tf
+++ b/modules/vpc/variables.tf
@@ -6,10 +6,6 @@ variable "vpc_cidr" {
   description = "CIDR block for the VPC"
   type        = string
 }
-variable "subnet_cidr" {
-  description = "List of CIDR blocks for the subnets"
-  type        = list(string)
-}
 variable "ssh_cidr_blocks" {
   description = "List of CIDR blocks allowed SSH"
   type        = list(string)


### PR DESCRIPTION
Now we'll just take the right number of /24 subnets; one for each AZ in the region. Requires that user provides a /20 CIDR range or larger for our VPC.