### PR TITLE
feat: add userdata support

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,28 @@ This is for an individual DevBox project.
 
 1. Find the initial AMI
 
+
+## CLI Usage
+
+Launch a project using the CLI:
+
+```bash
+devbox launch my-project \
+  --instance-type t3.medium \
+  --key-pair devbox-key \
+  --base-ami ami-0123456789abcdef0
+```
+
+Optionally pass cloud-init user data (shell script or `#cloud-config`) with
+`--userdata-file`:
+
+```bash
+devbox launch my-project \
+  --instance-type t3.medium \
+  --key-pair devbox-key \
+  --userdata-file ./userdata.sh
+```
+
 ## Troubleshooting
 
 ### connect to host `<ip>` port 22: Connection refused

--- a/src/devbox/cli.py
+++ b/src/devbox/cli.py
@@ -105,6 +105,7 @@ def launch(
     """Launch a new DevBox instance.
 
     PROJECT is the name of the project to launch.
+    Optionally pass cloud-init user data with --userdata-file.
     """
     from .launch import launch_programmatic
 

--- a/src/devbox/cli.py
+++ b/src/devbox/cli.py
@@ -2,6 +2,7 @@
 
 This module provides the Click-based CLI for managing DevBox instances.
 """
+
 import sys
 import click
 from typing import Optional
@@ -9,22 +10,24 @@ from typing import Optional
 from .devbox_manager import DevBoxManager
 from .console_output import ConsoleOutput
 
+
 @click.group()
 @click.version_option()
 @click.pass_context
 def cli(ctx):
     """DevBox - AWS EC2 Development Environment Manager."""
     ctx.ensure_object(dict)
-    ctx.obj['console'] = ConsoleOutput()
+    ctx.obj["console"] = ConsoleOutput()
 
     try:
-        ctx.obj['manager'] = DevBoxManager()
+        ctx.obj["manager"] = DevBoxManager()
     except Exception as e:
-        ctx.obj['console'].print_error(f"Failed to initialize AWS clients: {str(e)}")
+        ctx.obj["console"].print_error(f"Failed to initialize AWS clients: {str(e)}")
         sys.exit(1)
 
+
 @cli.command()
-@click.argument('project', required=False)
+@click.argument("project", required=False)
 @click.pass_context
 def status(ctx, project: Optional[str] = None):
     """Show status of DevBox resources.
@@ -32,8 +35,8 @@ def status(ctx, project: Optional[str] = None):
     If PROJECT is provided, only show resources for that project.
     Otherwise, show all resources.
     """
-    console = ctx.obj['console']
-    manager = ctx.obj['manager']
+    console = ctx.obj["console"]
+    manager = ctx.obj["manager"]
 
     try:
         # List instances, volumes, and snapshots
@@ -50,13 +53,14 @@ def status(ctx, project: Optional[str] = None):
         console.print_error(f"Failed to retrieve status: {str(e)}")
         sys.exit(1)
 
+
 @cli.command()
-@click.argument('instance_id')
+@click.argument("instance_id")
 @click.pass_context
 def terminate(ctx, instance_id: str):
     """Terminate a DevBox instance by its ID."""
-    console = ctx.obj['console']
-    manager = ctx.obj['manager']
+    console = ctx.obj["console"]
+    manager = ctx.obj["manager"]
 
     try:
         success, message = manager.terminate_instance(instance_id, console)
@@ -69,23 +73,42 @@ def terminate(ctx, instance_id: str):
         console.print_error(f"Failed to terminate instance: {str(e)}")
         sys.exit(1)
 
+
 @cli.command()
-@click.argument('project')
-@click.option('--instance-type', help='EC2 instance type (uses last instance type if not specified)')
-@click.option('--key-pair', help='SSH key pair name (uses last keypair if not specified)')
-@click.option('--volume-size', type=int, default=0, help='Root volume size in GB')
-@click.option('--base-ami', help='Base AMI ID for new instances')
-@click.option('--param-prefix', default='/devbox', help='SSM parameter prefix')
+@click.argument("project")
+@click.option(
+    "--instance-type",
+    help="EC2 instance type (uses last instance type if not specified)",
+)
+@click.option(
+    "--key-pair", help="SSH key pair name (uses last keypair if not specified)"
+)
+@click.option("--volume-size", type=int, default=0, help="Root volume size in GB")
+@click.option("--base-ami", help="Base AMI ID for new instances")
+@click.option("--param-prefix", default="/devbox", help="SSM parameter prefix")
+@click.option(
+    "--userdata-file",
+    type=click.Path(exists=True),
+    help="Path to userdata script file (cloud-init format)",
+)
 @click.pass_context
-def launch(ctx, project: str, instance_type: Optional[str], key_pair: Optional[str],
-          volume_size: int, base_ami: Optional[str], param_prefix: str):
+def launch(
+    ctx,
+    project: str,
+    instance_type: Optional[str],
+    key_pair: Optional[str],
+    volume_size: int,
+    base_ami: Optional[str],
+    param_prefix: str,
+    userdata_file: Optional[str],
+):
     """Launch a new DevBox instance.
 
     PROJECT is the name of the project to launch.
     """
     from .launch import launch_programmatic
 
-    console = ctx.obj['console']
+    console = ctx.obj["console"]
 
     try:
         launch_programmatic(
@@ -94,16 +117,18 @@ def launch(ctx, project: str, instance_type: Optional[str], key_pair: Optional[s
             key_pair=key_pair,
             volume_size=volume_size,
             base_ami=base_ami,
-            param_prefix=param_prefix
+            param_prefix=param_prefix,
+            userdata_file=userdata_file,
         )
     except Exception as e:
         console.print_error(f"Failed to launch instance: {str(e)}")
         sys.exit(1)
 
+
 @cli.command()
-@click.argument('project')
-@click.option('--base-ami', required=True, help='Base AMI ID for the project')
-@click.option('--param-prefix', default='/devbox', help='SSM parameter prefix')
+@click.argument("project")
+@click.option("--base-ami", required=True, help="Base AMI ID for the project")
+@click.option("--param-prefix", default="/devbox", help="SSM parameter prefix")
 @click.pass_context
 def new(ctx, project: str, base_ami: str, param_prefix: str):
     """Create a new DevBox project without launching an instance.
@@ -112,21 +137,21 @@ def new(ctx, project: str, base_ami: str, param_prefix: str):
     """
     from .new import new_project_programmatic
 
-    console = ctx.obj['console']
+    console = ctx.obj["console"]
 
     try:
         new_project_programmatic(
-            project=project,
-            base_ami=base_ami,
-            param_prefix=param_prefix
+            project=project, base_ami=base_ami, param_prefix=param_prefix
         )
     except Exception as e:
         console.print_error(f"Failed to create project: {str(e)}")
         sys.exit(1)
 
+
 def main():
     """Entry point for the CLI."""
     cli(obj={})
+
 
 if __name__ == "__main__":
     main()

--- a/src/devbox/launch.py
+++ b/src/devbox/launch.py
@@ -311,7 +311,7 @@ def launch_instance(
         volumes: List of volume mappings
         project: Project name for tagging
         az_name: Availability zone name for logging
-        userdata: Optional base64-encoded userdata string
+        userdata: Optional user data string (raw; SDK handles encoding)
 
     Returns:
         Tuple of (instance, instance_id, error) where:
@@ -748,7 +748,7 @@ def launch_instance_in_azs(
         key_name: Name of the key pair for SSH access
         volumes: List of volume mappings
         project: Project name for tagging
-        userdata: Optional base64-encoded userdata string
+        userdata: Optional user data string (raw; SDK handles encoding)
 
     Returns:
         Tuple of (instance, instance_id, instance_info) on success

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -272,6 +272,7 @@ class TestLaunchCommand:
             volume_size=0,  # default
             base_ami=None,
             param_prefix="/devbox",  # default
+            userdata_file=None,  # default
         )
 
     @patch("devbox.launch.launch_programmatic")
@@ -306,6 +307,7 @@ class TestLaunchCommand:
             volume_size=200,
             base_ami="ami-12345678",
             param_prefix="/custom",
+            userdata_file=None,  # default
         )
 
     @patch("devbox.launch.launch_programmatic")
@@ -360,6 +362,7 @@ class TestLaunchCommand:
             volume_size=0,
             base_ami=None,
             param_prefix="/devbox",
+            userdata_file=None,  # default
         )
 
     @patch("devbox.launch.launch_programmatic")
@@ -381,6 +384,7 @@ class TestLaunchCommand:
             volume_size=0,
             base_ami=None,
             param_prefix="/devbox",
+            userdata_file=None,  # default
         )
 
     @patch("devbox.launch.launch_programmatic")
@@ -402,6 +406,7 @@ class TestLaunchCommand:
             volume_size=0,
             base_ami=None,
             param_prefix="/devbox",
+            userdata_file=None,  # default
         )
 
     @pytest.mark.parametrize(
@@ -439,6 +444,54 @@ class TestLaunchCommand:
         assert result.exit_code == 0
         call_args = mock_launch.call_args
         assert call_args[1]["volume_size"] == expected
+
+    @patch("devbox.launch.launch_programmatic")
+    @patch("devbox.cli.ConsoleOutput")
+    def test_launch_with_userdata_file(self, mock_console_class, mock_launch, tmp_path):
+        """Test launch command with userdata file option."""
+        mock_console = MagicMock()
+        mock_console_class.return_value = mock_console
+
+        userdata_file = tmp_path / "userdata.sh"
+        userdata_file.write_text("#!/bin/bash\necho 'Hello World'")
+
+        result = self.runner.invoke(
+            cli,
+            [
+                "launch",
+                "test-project",
+                "--instance-type",
+                "t3.medium",
+                "--key-pair",
+                "my-key",
+                "--userdata-file",
+                str(userdata_file),
+            ],
+        )
+
+        assert result.exit_code == 0
+        call_args = mock_launch.call_args
+        assert "userdata_file" in call_args[1]
+        assert call_args[1]["userdata_file"] == str(userdata_file)
+
+    def test_launch_userdata_file_not_found(self):
+        """Test launch command with non-existent userdata file."""
+        result = self.runner.invoke(
+            cli,
+            [
+                "launch",
+                "test-project",
+                "--instance-type",
+                "t3.medium",
+                "--key-pair",
+                "my-key",
+                "--userdata-file",
+                "/nonexistent/userdata.sh",
+            ],
+        )
+
+        assert result.exit_code != 0
+        assert "does not exist" in result.output or "Invalid value" in result.output
 
 
 @patch("devbox.cli.cli")
@@ -558,6 +611,7 @@ class TestIntegrationScenarios:
             volume_size=150,
             base_ami="ami-0abcdef1234567890",
             param_prefix="/mycompany/devbox",
+            userdata_file=None,  # default
         )
 
 


### PR DESCRIPTION
This pull request enhances the DevBox CLI and launch script with improved option handling, user data script support, and overall code consistency. The most significant update is the addition of a `--userdata-file` option to allow passing a cloud-init script when launching a new EC2 instance. Additionally, the code has been refactored for better readability and consistency, especially in argument parsing and dictionary key usage.

**User data script support:**

* Added a `--userdata-file` option to the `launch` CLI command and the `launch_programmatic` interface, allowing users to specify a cloud-init format script to be passed as instance user data. This includes a new `read_userdata_file` helper and the necessary wiring in both `cli.py` and `launch.py` to read and pass the file contents. [[1]](diffhunk://#diff-c9694ea3eab815e1831a16892caf29a66f0afffb33292e2ff7fa4a74fe14b2e8R76-R111) [[2]](diffhunk://#diff-b2c6fa741fc6f9f3fdca02c491e822cb75cae58ad7f5b93f006196ec672fc73fR39-R59) [[3]](diffhunk://#diff-b2c6fa741fc6f9f3fdca02c491e822cb75cae58ad7f5b93f006196ec672fc73fL50-R108) [[4]](diffhunk://#diff-b2c6fa741fc6f9f3fdca02c491e822cb75cae58ad7f5b93f006196ec672fc73fR300) [[5]](diffhunk://#diff-b2c6fa741fc6f9f3fdca02c491e822cb75cae58ad7f5b93f006196ec672fc73fL299-R375)

**CLI and argument parsing improvements:**

* Standardized the use of double quotes for Click argument and option names, and restructured multi-line option definitions for clarity in `cli.py`. [[1]](diffhunk://#diff-c9694ea3eab815e1831a16892caf29a66f0afffb33292e2ff7fa4a74fe14b2e8R5-R39) [[2]](diffhunk://#diff-c9694ea3eab815e1831a16892caf29a66f0afffb33292e2ff7fa4a74fe14b2e8R56-R63) [[3]](diffhunk://#diff-c9694ea3eab815e1831a16892caf29a66f0afffb33292e2ff7fa4a74fe14b2e8L97-R131) [[4]](diffhunk://#diff-c9694ea3eab815e1831a16892caf29a66f0afffb33292e2ff7fa4a74fe14b2e8L115-R155)
* Updated the argument parser in `launch.py` to use more readable multi-line calls and consistent double quotes.

**General code consistency and cleanup:**

* Improved dictionary key usage throughout the CLI to use double quotes for consistency. [[1]](diffhunk://#diff-c9694ea3eab815e1831a16892caf29a66f0afffb33292e2ff7fa4a74fe14b2e8R5-R39) [[2]](diffhunk://#diff-c9694ea3eab815e1831a16892caf29a66f0afffb33292e2ff7fa4a74fe14b2e8R56-R63) [[3]](diffhunk://#diff-c9694ea3eab815e1831a16892caf29a66f0afffb33292e2ff7fa4a74fe14b2e8L97-R131) [[4]](diffhunk://#diff-c9694ea3eab815e1831a16892caf29a66f0afffb33292e2ff7fa4a74fe14b2e8L115-R155)
* Minor improvements to error handling, code formatting, and documentation for better maintainability and clarity. [[1]](diffhunk://#diff-b2c6fa741fc6f9f3fdca02c491e822cb75cae58ad7f5b93f006196ec672fc73fL23-R28) [[2]](diffhunk://#diff-b2c6fa741fc6f9f3fdca02c491e822cb75cae58ad7f5b93f006196ec672fc73fL108-R139) [[3]](diffhunk://#diff-b2c6fa741fc6f9f3fdca02c491e822cb75cae58ad7f5b93f006196ec672fc73fL134-R163) [[4]](diffhunk://#diff-b2c6fa741fc6f9f3fdca02c491e822cb75cae58ad7f5b93f006196ec672fc73fL167-R212) [[5]](diffhunk://#diff-b2c6fa741fc6f9f3fdca02c491e822cb75cae58ad7f5b93f006196ec672fc73fL213-R259) [[6]](diffhunk://#diff-b2c6fa741fc6f9f3fdca02c491e822cb75cae58ad7f5b93f006196ec672fc73fL246-R278) [[7]](diffhunk://#diff-b2c6fa741fc6f9f3fdca02c491e822cb75cae58ad7f5b93f006196ec672fc73fL396-R432) [[8]](diffhunk://#diff-b2c6fa741fc6f9f3fdca02c491e822cb75cae58ad7f5b93f006196ec672fc73fL416-R453) [[9]](diffhunk://#diff-b2c6fa741fc6f9f3fdca02c491e822cb75cae58ad7f5b93f006196ec672fc73fL425-R466) [[10]](diffhunk://#diff-b2c6fa741fc6f9f3fdca02c491e822cb75cae58ad7f5b93f006196ec672fc73fL463-R503) [[11]](diffhunk://#diff-b2c6fa741fc6f9f3fdca02c491e822cb75cae58ad7f5b93f006196ec672fc73fL475-R520)

---

This PR chooses not to store userdata in AWS because you most likely will not rerun userdata on every launch since most of the time it is used to populate the home directory. This enables you to also use other scripts on launching the new instance if needed.