### PR TITLE
Consistent support for `--param-prefix` override

### DIFF
--- a/src/devbox/cli.py
+++ b/src/devbox/cli.py
@@ -47,7 +47,7 @@ def cli(ctx):
 @click.argument('project', required=False)
 @param_prefix_option
 @click.pass_context
-def status(ctx, project: Optional[str] = None, param_prefix: str = DEFAULT_PARAM_PREFIX):
+def status(ctx, project: Optional[str] = None, param_prefix: str):
     """Show status of DevBox resources.
 
     If PROJECT is provided, only show resources for that project.
@@ -75,7 +75,7 @@ def status(ctx, project: Optional[str] = None, param_prefix: str = DEFAULT_PARAM
 @click.argument('instance_id')
 @param_prefix_option
 @click.pass_context
-def terminate(ctx, instance_id: str, param_prefix: str = DEFAULT_PARAM_PREFIX):
+def terminate(ctx, instance_id: str, param_prefix: str):
     """Terminate a DevBox instance by its ID."""
     console = ctx.obj['console']
     manager = get_manager(console, param_prefix)

--- a/src/devbox/cli.py
+++ b/src/devbox/cli.py
@@ -47,7 +47,11 @@ def cli(ctx):
 @click.argument('project', required=False)
 @param_prefix_option
 @click.pass_context
-def status(ctx, project: Optional[str] = None, param_prefix: str):
+def status(
+    ctx,
+    project: Optional[str] = None,
+    param_prefix: str = DEFAULT_PARAM_PREFIX
+):
     """Show status of DevBox resources.
 
     If PROJECT is provided, only show resources for that project.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -120,6 +120,27 @@ class TestStatusCommand:
 
     @patch("devbox.cli.DevBoxManager")
     @patch("devbox.cli.ConsoleOutput")
+    def test_status_with_param_prefix_option(
+        self, mock_console_class, mock_manager_class
+    ):
+        mock_console = MagicMock()
+        mock_manager = MagicMock()
+        mock_console_class.return_value = mock_console
+        mock_manager_class.return_value = mock_manager
+
+        mock_manager.list_instances.return_value = []
+        mock_manager.list_volumes.return_value = []
+        mock_manager.list_snapshots.return_value = []
+
+        result = self.runner.invoke(
+            cli, ["status", "--param-prefix", "/custom/devbox"]
+        )
+
+        assert result.exit_code == 0
+        mock_manager_class.assert_called_once_with(prefix="custom/devbox")
+
+    @patch("devbox.cli.DevBoxManager")
+    @patch("devbox.cli.ConsoleOutput")
     def test_status_manager_error(self, mock_console_class, mock_manager_class):
         mock_console = MagicMock()
         mock_manager = MagicMock()
@@ -208,6 +229,24 @@ class TestTerminateCommand:
             "i-nonexistent", mock_console
         )
         mock_console.print_error.assert_called_once_with("Instance not found")
+
+    @patch("devbox.cli.DevBoxManager")
+    @patch("devbox.cli.ConsoleOutput")
+    def test_terminate_with_param_prefix_option(
+        self, mock_console_class, mock_manager_class
+    ):
+        mock_console = MagicMock()
+        mock_manager = MagicMock()
+        mock_console_class.return_value = mock_console
+        mock_manager_class.return_value = mock_manager
+        mock_manager.terminate_instance.return_value = (True, "Terminated")
+
+        result = self.runner.invoke(
+            cli, ["terminate", "i-1234567890abcdef0", "--param-prefix", "/custom"]
+        )
+
+        assert result.exit_code == 0
+        mock_manager_class.assert_called_once_with(prefix="custom")
 
     @patch("devbox.cli.DevBoxManager")
     @patch("devbox.cli.ConsoleOutput")
@@ -699,3 +738,87 @@ class TestCommandChaining:
         # Verify each command called its respective methods
         mock_manager.list_instances.assert_called()
         mock_manager.terminate_instance.assert_called_once_with("i-test", mock_console)
+
+
+class TestParamPrefixEnvironmentOverrides:
+    def setup_method(self):
+        self.runner = CliRunner()
+
+    @patch("devbox.cli.DevBoxManager")
+    @patch("devbox.cli.ConsoleOutput")
+    def test_status_uses_param_prefix_from_env(
+        self, mock_console_class, mock_manager_class
+    ):
+        mock_console = MagicMock()
+        mock_manager = MagicMock()
+        mock_console_class.return_value = mock_console
+        mock_manager_class.return_value = mock_manager
+        mock_manager.list_instances.return_value = []
+        mock_manager.list_volumes.return_value = []
+        mock_manager.list_snapshots.return_value = []
+
+        result = self.runner.invoke(
+            cli, ["status"], env={"DEVBOX_PARAM_PREFIX": "/env/devbox"}
+        )
+
+        assert result.exit_code == 0
+        mock_manager_class.assert_called_once_with(prefix="env/devbox")
+
+    @patch("devbox.cli.DevBoxManager")
+    @patch("devbox.cli.ConsoleOutput")
+    def test_terminate_uses_param_prefix_from_env(
+        self, mock_console_class, mock_manager_class
+    ):
+        mock_console = MagicMock()
+        mock_manager = MagicMock()
+        mock_console_class.return_value = mock_console
+        mock_manager_class.return_value = mock_manager
+        mock_manager.terminate_instance.return_value = (True, "Terminated")
+
+        result = self.runner.invoke(
+            cli,
+            ["terminate", "i-1234567890abcdef0"],
+            env={"DEVBOX_PARAM_PREFIX": "/env/devbox"},
+        )
+
+        assert result.exit_code == 0
+        mock_manager_class.assert_called_once_with(prefix="env/devbox")
+
+    @patch("devbox.launch.launch_programmatic")
+    @patch("devbox.cli.ConsoleOutput")
+    def test_launch_uses_param_prefix_from_env(self, mock_console_class, mock_launch):
+        mock_console = MagicMock()
+        mock_console_class.return_value = mock_console
+
+        result = self.runner.invoke(
+            cli, ["launch", "test-project"], env={"DEVBOX_PARAM_PREFIX": "/env/devbox"}
+        )
+
+        assert result.exit_code == 0
+        mock_launch.assert_called_once_with(
+            project="test-project",
+            instance_type=None,
+            key_pair=None,
+            volume_size=0,
+            base_ami=None,
+            param_prefix="/env/devbox",
+        )
+
+    @patch("devbox.new.new_project_programmatic")
+    @patch("devbox.cli.ConsoleOutput")
+    def test_new_uses_param_prefix_from_env(self, mock_console_class, mock_new):
+        mock_console = MagicMock()
+        mock_console_class.return_value = mock_console
+
+        result = self.runner.invoke(
+            cli,
+            ["new", "test-project", "--base-ami", "ami-12345678"],
+            env={"DEVBOX_PARAM_PREFIX": "/env/devbox"},
+        )
+
+        assert result.exit_code == 0
+        mock_new.assert_called_once_with(
+            project="test-project",
+            base_ami="ami-12345678",
+            param_prefix="/env/devbox",
+        )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -803,22 +803,3 @@ class TestParamPrefixEnvironmentOverrides:
             base_ami=None,
             param_prefix="/env/devbox",
         )
-
-    @patch("devbox.new.new_project_programmatic")
-    @patch("devbox.cli.ConsoleOutput")
-    def test_new_uses_param_prefix_from_env(self, mock_console_class, mock_new):
-        mock_console = MagicMock()
-        mock_console_class.return_value = mock_console
-
-        result = self.runner.invoke(
-            cli,
-            ["new", "test-project", "--base-ami", "ami-12345678"],
-            env={"DEVBOX_PARAM_PREFIX": "/env/devbox"},
-        )
-
-        assert result.exit_code == 0
-        mock_new.assert_called_once_with(
-            project="test-project",
-            base_ami="ami-12345678",
-            param_prefix="/env/devbox",
-        )


### PR DESCRIPTION
This was missing from some of the CLI subcommands (status and terminate). Additionally, this PR makes it so that you can use an env var to set the param prefix.